### PR TITLE
Accessibility Control

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -728,9 +728,7 @@ resource.request().onComplete { [weak self] response in
 
 ## Access Control
 
-Full access control annotation in tutorials can distract from the main topic and is not required. Using `private` and `fileprivate` appropriately, however, adds clarity and promotes encapsulation. Prefer `private` to `fileprivate` when possible. Using extensions may require you to use `fileprivate`.
-
-Only explicitly use `open`, `public`, and `internal` when you require a full access control specification.
+Full access control annotation should always be specified unless you wish to have the value of `internal`, in which case you can leave this out as it is implied. Using `private` and `fileprivate` appropriately, adds clarity and promotes encapsulation. Prefer `private` to `fileprivate` when possible. Using extensions may require you to use `fileprivate`.
 
 Use access control as the leading property specifier. The only things that should come before access control are the `static` specifier or attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
 


### PR DESCRIPTION
We decided internally that using private in all cases was the preferred syntax